### PR TITLE
Fm Modulator Updates

### DIFF
--- a/radioDiags/FmModulator/FmModulator.h
+++ b/radioDiags/FmModulator/FmModulator.h
@@ -3,7 +3,7 @@
 //**************************************************************************
 //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
 // This class implements a signal processing block known as an FM
-// modulator.  This class has a configurable modulator gain.
+// modulator.
 ///_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
 
 #ifndef __FMMODULATOR__
@@ -23,7 +23,7 @@ class FmModulator
   ~FmModulator(void);
 
   void resetModulator(void);
-  void setModulatorGain(float gain);
+  void setFrequencyDeviation(float deviaton);
 
   void acceptData(int16_t *bufferPtr,
                   uint32_t bufferLength,
@@ -43,11 +43,11 @@ class FmModulator
   //*******************************************************************
   // Attributes.
   //*******************************************************************
-  // This gain maps the phase accumulator to an information signal.
-  float modulatorGain;
+  // Allowable frequency deviation.
+  float frequencyDeviation;
 
   // Phase accumulator support.
-  float theta;
+  float phaseAccumulator;
 
   // This is the complex output data that is created by the modulator.
   int16_t iModulatedData[512];

--- a/radioDiags/FmModulator/README.txt
+++ b/radioDiags/FmModulator/README.txt
@@ -12,6 +12,15 @@ as the examples in some DSP books have liberally used.
 Note that the halfband filters didn't need to be modified since the passband
 and stopband ripples are equal in that case.
 Chris G. 10/26/2019
+
+The modulation function has been updated so that it more intuitive to use.
+Rather than using a modulator gain, the FM deviation is used.  A more way
+of computing the phase increment is now performed.  I didn't like variable 
+names like theta and newTheta.  Those terms have been replaced with
+phaseAccumulator and phaseIncrement.  Basically, the FM modulator is
+implemented with an NCO (numerically controlled oscillator), and I wanted
+this to be clear.
+Chris G. 09/30/2020 
 ******************************************************************************
 
 /_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/

--- a/radioDiags/hdr_diags/Radio.h
+++ b/radioDiags/hdr_diags/Radio.h
@@ -97,7 +97,7 @@ class Radio
   // Modulator support.
   void setModulatorMode(uint8_t mode);
   void setAmModulationIndex(float modulationIndex);
-  void setFmModulatorGain(float gain);
+  void setFmDeviation(float deviation);
 
   void displayInternalInformation(void);
 

--- a/radioDiags/src_diags/Radio.cc
+++ b/radioDiags/src_diags/Radio.cc
@@ -1948,31 +1948,31 @@ void Radio::setAmModulationIndex(float modulationIndex)
 
 /*****************************************************************************
 
-  Name: setFmModulatorGain
+  Name: setFmDeviation
 
-  Purpose: The purpose of this function is to set the gain of the
-  FM modulator.
+  Purpose: The purpose of this function is to set the frequency deviation
+  of the FM modulator.
 
-  Calling Sequence: setFmModulatorGain(gain)
+  Calling Sequence: setFmDeviation(deviation)
 
   Inputs:
 
-    gain - The modulator gain.
+    deviation - The frequency deviation.
 
   Outputs:
 
     None.
 
 *****************************************************************************/
-void Radio::setFmModulatorGain(float gain)
+void Radio::setFmDeviation(float deviation)
 {
 
   // Notifier the FM demodulator to set its gain.
-  fmModulatorPtr->setModulatorGain(gain);
+  fmModulatorPtr->setFrequencyDeviation(deviation);
 
   return;
 
-} // setFmModulatorGain
+} // setFmDeviation
 
 /**************************************************************************
 

--- a/radioDiags/src_diags/diagUi.cc
+++ b/radioDiags/src_diags/diagUi.cc
@@ -83,7 +83,7 @@ static void cmdSetFmDemodGain(char *bufferPtr);
 static void cmdSetWbFmDemodGain(char *bufferPtr);
 static void cmdSetSsbDemodGain(char *bufferPtr);
 static void cmdSetAmModIndex(char *bufferPtr);
-static void cmdSetFmModGain(char *bufferPtr);
+static void cmdSetFmModDeviation(char *bufferPtr);
 static void cmdEnableFrontendAmp(char *bufferPtr);
 static void cmdDisableFrontendAmp(char *bufferPtr);
 static void cmdSetTxIfGain(char *bufferPtr);
@@ -136,7 +136,8 @@ static const commandEntry commandTable[] =
   {"set","wbfmdemodgain",cmdSetWbFmDemodGain}, // set wbfmdemodgain gain
   {"set","ssbdemodgain",cmdSetSsbDemodGain},   // set ssbdemodgain gain
   {"set","ammodindex",cmdSetAmModIndex},     // set ammodindex modulationindex 
-  {"set","fmmodgain",cmdSetFmModGain},         // set fmmodgain gain
+  {"set","fmmoddeviation",cmdSetFmModDeviation},
+                                             // set fmmoddeviation deviation 
   {"enable","frontendamp",cmdEnableFrontendAmp}, // enable frontendamp
   {"disable","frontendamp",cmdDisableFrontendAmp}, // disable frontendamp
   {"set","txifgain",cmdSetTxIfGain},           // set txifgain gain
@@ -817,16 +818,16 @@ static void cmdSetAmModIndex(char *bufferPtr)
 
 /*****************************************************************************
 
-  Name: cmdSetFmDemodGain
+  Name: cmdSetFmModDeviation
 
   Purpose: The purpose of this function is to set the gain of the FM
   modulator in the system.
 
   The syntax for the corresponding command is the following:
 
-    "set fmmodgain gain"
+    "set fmmoddeviaton deviation"
 
-  Calling Sequence: cmdSetFmModGain(bufferPtr)
+  Calling Sequence: cmdSetFmModDeviation(bufferPtr)
 
   Inputs:
 
@@ -837,28 +838,28 @@ static void cmdSetAmModIndex(char *bufferPtr)
     None.
 
 *****************************************************************************/
-static void cmdSetFmModGain(char *bufferPtr)
+static void cmdSetFmModDeviation(char *bufferPtr)
 {
-  float gain;
+  float deviation;
 
   // Retrieve value
-  sscanf(bufferPtr,"%f",&gain);
+  sscanf(bufferPtr,"%f",&deviation);
 
-  if (gain >= 0)
+  if ((deviation > 0) && (deviation <= 3500))
   {
-    // Set the modulator gain.
-    diagUi_radioPtr->setFmModulatorGain(gain);
+    // Set the modulator deviation.
+    diagUi_radioPtr->setFmDeviation(deviation);
 
-    nprintf(stderr,"FM Modulator gain set to %f.\n",gain);
+    nprintf(stderr,"FM Modulator deviation set to %fHz.\n",deviation);
   } // if
   else
   {
-    nprintf(stderr,"Error: gain >= 0.\n");
+    nprintf(stderr,"Error: 0 < deviation <= 3500.\n");
   } // else
 
   return;
 
-} // cmdSetFmDemodGain
+} // cmdSetFmModDeviation
 
 /*****************************************************************************
 
@@ -1946,7 +1947,7 @@ static void cmdHelp(void)
   nprintf(stderr,"set wbfmdemodgain <gain>\n");
   nprintf(stderr,"set ssbdemodgain <gain>\n");
   nprintf(stderr,"set ammodindex <modulation index>\n");
-  nprintf(stderr,"set fmmodgain <gain>\n");
+  nprintf(stderr,"set fmmoddeviation <deviation in Hz>\n");
   nprintf(stderr,"enable frontendamp\n");
   nprintf(stderr,"disable frontendamp\n");
   nprintf(stderr,"set txifgain <gain in dB>\n");


### PR DESCRIPTION
I decided to make the FM modulator more intuitive to use. Rather than the kludgey gain parameter that I had initially chosen to use, I now use the frequency deviation as the parameter of choice. The sample rate, Fs, is 8000S/s, there the maximum frequency of operation of the NCO would be Fs/2 = 4000Hz. That's a bit high, so I limit the deviation to 3500Hz. I've changed the user command that allows the gain (formerly) of the FM modulator to that of setting the FM deviation with a range of 1Hz through 3500Hz.