### PR TITLE
This commit incorporates the changes listed below:

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -176,7 +176,8 @@ start receiver
 stop receiver
 start livestream
 stop livestream
-start fscan <startfrequency> <endfrequency> <stepsize>
+set fscanvalues <startfrequency> <endfrequency> <stepsize>
+start fscan
 stop fscan
 start frequencysweep <startfrequency> <stepsize> <count> <dwelltime>
 stop frequencysweep
@@ -296,9 +297,69 @@ Modulation Mode        : USB
 
 ******************** End Get Radio Info Output *************************
 
-Anyway, if you have any questions, you can always catch me on freenode IRC.
-I use the nick wizardyesterday or adhoc_rf_rocks.  My day-to-day nick is
-wizardyesterday though.
+The new features I have added are listed below:
+
+1. A signal squelch that works directly with the average magnitude of
+a received IQ data block.
+
+2. A frequency scanner that lets you specify a start frequency, an end
+frequency, and a frequency step. This collaborates with the squelch
+such that, when scanning, if a signal exceeds the squelch threshold,
+the scan will stop so that you can hear the demodulated audio of the
+signal. When the signal goes away, frequency scan will continue.
+
+3. An automatic gain control (AGC) for the receiver.  For my purposes,
+this was a much-needed feature since the HackRF doesn't provide AGC
+Functionality.  I wasn't a fan of always changing the system gain
+parameters manually as I listened to different frequencies.  For
+example, I might tune to a local weather station at one time, and tune
+to a strong local FM radio station (FM broadcast band) at another time.
+There can be a significant variation in signal level between these two
+scenarios.  This is handled automatically by the AGC.
+
+When the user types "get fscaninfo" (for the frequency scanner), the
+output appears as illustratedbelow.  Not that the start frequency, the
+end frequency, and the frequency increment are configurable.  See the
+help command output for the syntax of the commands realated to the
+frequency scanner (fscan).
+
+******************** Begin GetFscainfo Info Output **********************
+
+--------------------------------------------
+Frequency Scanner Internal Information
+--------------------------------------------
+Scanner State             : Scanning
+Start Frequency           : 120350000 Hz
+End Frequency             : 120550000 Hz
+Frequency Increment       : 25000 Hz
+Current Frequency         : 120475000 Hz
+
+******************** End Get Fscainfo Output  **** **********************
+
+When the user types "get agcinfo" (for the AGC), the output appears as
+illustrated below.  Note that the lowpass filter coefficient and the
+operating point are user configurable.  See the help command output for
+the syntax of the commands realated to the AGC.
+
+******************** Begin Getagcinfo Info Output **********************
+
+--------------------------------------------
+AGC Internal Information
+--------------------------------------------
+AGC Emabled               : Yes
+Signal Magnitude          : 55
+Lowpass Filter Coefficient: 0.100
+Operating Point           : -6 dBFs
+RF Gain                   : 0 dB
+IF Gain                   : 40 dB
+Baseband Gain             : 50 dB
+
+******************** End Get Agcinfo Output  **** **********************
+
+
+Anyway, if you have any questions, you can always catch me on libera IRC.
+I use the nick wizardyesterday.  I can also be reached on Facebook as
+Chris Gianakopoulos.
 
 Oh one last thing.  Anybody can use my software without grief.  I guess I'll
 have to put the GNU open source stuff at the beginning of my files, and that

--- a/radioDiags/hdr_diags/FrequencyScanner.h
+++ b/radioDiags/hdr_diags/FrequencyScanner.h
@@ -18,13 +18,17 @@ class FrequencyScanner
 
   enum state_t {Idle, Scanning};
 
-  FrequencyScanner(Radio *radioPtr,
-                   uint64_t startFrequencyInHertz,
-                   uint64_t endFrequencyInHertz,
-                   uint64_t frequencyIncrementInHertz);
+  FrequencyScanner(Radio *radioPtr);
 
   ~FrequencyScanner(void);
 
+  bool setScanParameters(uint64_t startFrequencyInHertz,
+                         uint64_t endFrequencyInHertz,
+                         uint64_t frequencyIncrementInHertz);
+
+  bool start(void);
+  bool stop(void);
+  bool isScanning(void);
   void run(bool signalPresent);
 
   void displayInternalInformation(void);
@@ -51,11 +55,11 @@ class FrequencyScanner
   // The end frequency of the sweep.
   uint64_t endFrequencyInHertz;
 
-  // The current frequency for display purposes.
-  uint64_t currentFrequencyInHertz;
-
   // The frequency step size to take during a scan.
   uint64_t frequencyIncrementInHertz;
+
+  // The current frequency of the sweep.
+  uint64_t currentFrequencyInHertz;
 
   // Pointer to a radio instance.
   Radio *radioPtr;

--- a/radioDiags/src_diags/FrequencyScanner.cc
+++ b/radioDiags/src_diags/FrequencyScanner.cc
@@ -9,9 +9,6 @@
 
 extern void nprintf(FILE *s,const char *formatPtr, ...);
 
-// This is needed to avoid race conditions upon instance destruction.
-static bool callbackEnabled;
-
 /**************************************************************************
 
   Name: signalStateCallback
@@ -38,14 +35,14 @@ static void signalStateCallback(bool signalPresent,void *contextPtr)
 {
   FrequencyScanner *thisPtr;
 
-  if (callbackEnabled)
-  {
-    // Reference the context pointer properly.
-    thisPtr = (FrequencyScanner *)contextPtr;
+  // Reference the context pointer properly.
+  thisPtr = (FrequencyScanner *)contextPtr;
 
+  if (thisPtr->isScanning())
+  {
     // Peform the processing.
     thisPtr->run(signalPresent);
-  } // ig
+  } // if
 
   return;
 
@@ -58,63 +55,46 @@ static void signalStateCallback(bool signalPresent,void *contextPtr)
   Purpose: The purpose of this function is to serve as the constructor
   of a FrequencyScanner object.
 
-  Calling Sequence: FrequencyScanner(radioPtr,
-                                     startFrequencyInHertz,
-                                     endFrequencyInHertz,
-                                     frequencyIncrementInHertz)
+  Calling Sequence: FrequencyScanner(radioPtr)
 
   Inputs:
 
     radioPtr - A pointer to a Radio instance.
-
-    startFrequencyInHertz - The start frequency of the scan.
-
-    endFrequencyInHz - The end frequency of the scan.
-
-    frequencyIncrementInHertz - The increment that is used to generate
-    the discrete frequencies. 
 
   Outputs:
 
     None.
 
 **************************************************************************/
-FrequencyScanner::FrequencyScanner(Radio *radioPtr,
-                                   uint64_t startFrequencyInHertz,
-                                   uint64_t endFrequencyInHertz,
-                                   uint64_t frequencyIncrementInHertz)
+FrequencyScanner::FrequencyScanner(Radio *radioPtr)
 {
   bool success;
 
   // Save for later use.
   this->radioPtr = radioPtr;
-  this->startFrequencyInHertz = startFrequencyInHertz;
-  this->endFrequencyInHertz = endFrequencyInHertz;
-  this->frequencyIncrementInHertz = frequencyIncrementInHertz;
+
+  // Set the parameters to harmless values.
+  startFrequencyInHertz = 162550000;
+  endFrequencyInHertz = 162550000;
+  frequencyIncrementInHertz = 0;
 
   // Start at the beginning.
   currentFrequencyInHertz = startFrequencyInHertz;
 
-  // Select initial frequency.
-  success = radioPtr->setReceiveFrequency(currentFrequencyInHertz);
-
-  // Indicate that the system is scanning.
-  scannerState = Scanning;
+  // Indicate that the system is idle.
+  scannerState = Idle;
 
   //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
   // Register the callback to the IqDataProcessor.
   //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
-  // Enable the callback function.
-  callbackEnabled = true;
-
   // Retrieve the object instance.
   dataProcessorPtr = radioPtr->getIqProcessor();
 
+  // Turn off notification.
+  dataProcessorPtr->disableSignalNotification();
+
   // Register the callback.
   dataProcessorPtr->registerSignalStateCallback(signalStateCallback,this);
-
-  // Allow callback processing.
-  dataProcessorPtr->enableSignalNotification();
   //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
 
   return;
@@ -143,7 +123,7 @@ FrequencyScanner::~FrequencyScanner(void)
 {
 
   // Disable callback function processing.
-  callbackEnabled = false;
+  scannerState = Idle;
 
   // Turn off nofication.
   dataProcessorPtr->disableSignalNotification();
@@ -154,6 +134,215 @@ FrequencyScanner::~FrequencyScanner(void)
   return;
 
 } // ~FrequencyScanner
+
+/**************************************************************************
+
+  Name: setScanParameters
+
+  Purpose: The purpose of this function is to set the scan parameters of
+  the frequency scanner.
+  Note, that the scanner must be in an idle state in order to change the
+  parameters.
+
+  Calling Sequence: success = setScanParameters(startFrequencyInHertz,
+                                                endFrequencyInHertz,
+                                                frequencyIncrementInHertz)
+
+  Inputs:
+
+    startFrequencyInHertz - The start frequency of the scan.
+
+    endFrequencyInHz - The end frequency of the scan.
+
+    frequencyIncrementInHertz - The increment that is used to generate
+    the discrete frequencies. 
+
+  Outputs:
+
+    success - A flag that indicates the outcome of the operation.  A
+    value of true indicates success, and a value of false indicates
+    that the operation was not successful.  A failure would occur if
+    the scanner is currently scanning.
+
+**************************************************************************/
+bool FrequencyScanner::setScanParameters(uint64_t startFrequencyInHertz,
+                                         uint64_t endFrequencyInHertz,
+                                         uint64_t frequencyIncrementInHertz)
+{
+  bool success;
+  bool result;
+
+  // Default to failure.
+  success = false;
+
+  if (scannerState == Idle)
+  {
+    // Store the values for use during scanning.
+    this->startFrequencyInHertz = startFrequencyInHertz;
+    this->endFrequencyInHertz = endFrequencyInHertz;
+    this->frequencyIncrementInHertz = frequencyIncrementInHertz;
+
+    // See where the radio is tuned.
+    currentFrequencyInHertz = radioPtr->getReceiveFrequency();
+
+    if ((currentFrequencyInHertz < startFrequencyInHertz) ||
+        (currentFrequencyInHertz > endFrequencyInHertz))
+    {
+      // Start at the beginning.
+      currentFrequencyInHertz = startFrequencyInHertz;
+
+      // Tune the radio.
+      result = radioPtr->setReceiveFrequency(startFrequencyInHertz);
+    } // if
+
+    // Indicate success.
+    success = true;
+  } // if
+
+  return (success);
+
+} // setScanParameters
+
+/**************************************************************************
+
+  Name: start
+
+  Purpose: The purpose of this function is to enable the frequency
+  scanner so that it can start scanning.
+
+  Calling Sequence: success = start();
+
+  Inputs:
+
+    None.
+
+  Outputs:
+
+    success - A flag that indicates whether or not the operation was
+    successful.  A value of true indicates that the operation was
+    successful, and a value of false indicates that the frequency
+    scanner was already scanning.
+
+**************************************************************************/
+bool FrequencyScanner::start(void)
+{
+  bool success;
+
+  // Default to failure.
+  success = false;
+
+  if (scannerState == Idle)
+  {
+    // Make state transition.
+    scannerState = Scanning;
+
+    // Allow callback notification.
+    dataProcessorPtr->enableSignalNotification();
+
+    // Indicate success.
+    success = true;
+  } // if
+
+  return (success);
+
+} // start
+
+/**************************************************************************
+
+  Name: stop
+
+  Purpose: The purpose of this function is to stop the frequency scanner
+  from scanning.
+
+  Calling Sequence: success = stop();
+
+  Inputs:
+
+    None.
+
+  Outputs:
+
+    success - A flag that indicates whether or not the operation was
+    successful.  A value of true indicates that the operation was
+    successful, and a value of false indicates that the frequency
+    scanner was already idle.
+
+**************************************************************************/
+bool FrequencyScanner::stop(void)
+{
+  bool success;
+
+  // Default to failure.
+  success = false;
+
+  if (scannerState == Scanning)
+  {
+    // Make state transition.
+    scannerState = Idle;
+
+    // Turn off nofication.
+    dataProcessorPtr->disableSignalNotification();
+
+    // Indicate success.
+    success = true;
+  } // if
+
+  return (success);
+
+} // stop
+
+/**************************************************************************
+
+  Name: isScanning
+
+  Purpose: The purpose of this function is to indicate whether or not
+  the frequency scanner is scanning.
+
+  Calling Sequence: status = isScanning()
+
+  Inputs:
+
+    None.
+
+  Outputs:
+
+    success - A flag that indicates whether or not the frequency
+    scanner is scanning.  A value of true indicates that the scanner
+    is scanning, and a value of false indicates that the scanner is
+    idle.
+
+**************************************************************************/
+bool FrequencyScanner::isScanning(void)
+{
+  bool status;
+
+  switch (scannerState)
+  {
+    case Idle:
+    {
+      // Indicate that the scanner is idle.
+      status = false;
+      break;
+    } // case
+
+    case Scanning:
+    {
+      // Indicate that the scanner is scanning.
+      status = true;
+      break;
+    } // case
+
+    default:
+    {
+      // Indicate that the scanner is idle.
+      status = false;
+      break;
+    } // case
+  } // switch
+
+  return (status);
+
+} // isScanning
 
 /**************************************************************************
 

--- a/radioDiags/src_diags/radioApp.cc
+++ b/radioDiags/src_diags/radioApp.cc
@@ -121,7 +121,7 @@ int main(int argc,char **argv)
   diagUi_radioPtr->setReceiveFrequency(transceiveFrequency);
 
   // Indicate that no frequency scanner has been allocated.
-  diagUi_frequencyScannerPtr = 0;
+  diagUi_frequencyScannerPtr = new FrequencyScanner(diagUi_radioPtr);
 
   // Indicate that no frequency sweeper has been allocated.
   diagUi_frequencySweeperPtr = 0;


### PR DESCRIPTION
1. Responsibility of instantiation of the frequency scanner has been moved
from the diag UI to the mainline code.

2. The user now has to configure the frequency scanner before starting a
scan if new frequency parameters are desired.

3. The user can enable/disable the scanner without having to change the
scanning parameters.  This allows the user to stop scanning (which
provides pause functionality), and restart the scan with the result that
the scan will continue from the last frequency for which the scanner was
stopped.

4. The frequency scanner exists for the whole lifetime of the program.

This should make things easier when if I decide to absorbe scanner
functionality into the Radio object. For now, I'll let it be a separate
Radio object application.