### PR TITLE
1. Responsibility of instantiation of the frequency scanner has been …

### DIFF
--- a/radioDiags/src_diags/FrequencyScanner.cc
+++ b/radioDiags/src_diags/FrequencyScanner.cc
@@ -187,7 +187,7 @@ bool FrequencyScanner::setScanParameters(uint64_t startFrequencyInHertz,
 
     //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
     // Indicate that things have possibly changed.
-    // The run() method will deal with this later.
+    // The start() method will deal with this later.
     //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
     newConfigurationAvailable = true;
     //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
@@ -224,12 +224,26 @@ bool FrequencyScanner::setScanParameters(uint64_t startFrequencyInHertz,
 bool FrequencyScanner::start(void)
 {
   bool success;
+  bool result;
 
   // Default to failure.
   success = false;
 
   if (scannerState == Idle)
   {
+    if (newConfigurationAvailable)
+    {
+      // Force this at the edge of the cliff.
+      currentFrequencyInHertz = endFrequencyInHertz;
+
+      // Select new frequency.
+      result = radioPtr->setReceiveFrequency(currentFrequencyInHertz);
+
+
+      // Negate the flag so that this processing occurs one time.
+      newConfigurationAvailable = false;
+    } // if
+
     // Make state transition.
     scannerState = Scanning;
 
@@ -364,15 +378,6 @@ bool FrequencyScanner::isScanning(void)
 void FrequencyScanner::run(bool signalPresent)
 {
   bool success;
-
-  if (newConfigurationAvailable)
-  {
-    // Force this at the edge of the cliff.
-    currentFrequencyInHertz = endFrequencyInHertz;
-
-    // Negate the flag so that this processing occurs one time.
-    newConfigurationAvailable = false;
-  } // if
 
   if (!signalPresent)
   {


### PR DESCRIPTION
…moved

from the diag UI to the mainline code.

2. The user now has to configure the frequency scanner before starting a
scan if new frequency parameters are desired.

3. The user can enable/disable the scanner without having to change the
scanning parameters.  This allows the user to stop scanning (which
provides pause functionality), and restart the scan with the result that
the scan will continue from the last frequency for which the scanner was
stopped.

4. The frequency scanner exists for the whole lifetime of the program.

This should make things easier when if I decide to absorb scanner
functionality into the Radio object. For now, I'll let it be a separate
Radio object application.