### PR TITLE
I increased the default setting of the AGC filter coefficient from 0.…

### DIFF
--- a/radioDiags/src_diags/AutomaticGainControl.cc
+++ b/radioDiags/src_diags/AutomaticGainControl.cc
@@ -110,8 +110,18 @@ AutomaticGainControl::AutomaticGainControl(Radio *radioPtr,
   // Initial condition of filter memory.
   filteredBasebandGainInDb = 40;
 
-  // Time constant.
-  alpha = 0.1;
+  //+++++++++++++++++++++++++++++++++++++++++++++++++
+  // Set the AGC time constant such that gain
+  // adjustment occurs rapidly while maintaining
+  // system stability.  Originally the value was set
+  // to a a value of 0.1, and the result was that
+  // the gain adjustment was so slow that weak
+  // signals would exceed the squelch threshold for
+  // a very short time; that is, most of the signal
+  // could not be heard.
+  //+++++++++++++++++++++++++++++++++++++++++++++++++
+  alpha = 0.9;
+  //+++++++++++++++++++++++++++++++++++++++++++++++++
   //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
 
   //_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/


### PR DESCRIPTION
…1 to

0.9.  With a setting of 0.1, the gain adjustment was so sluggish that signals
generally didn't exceed squelch (or if they did, it was for a very short
time).  With a setting of 0.9, the system now works, and I can hear full
transmissions breaking squelch.