### PR TITLE
When I refactored code, a bug got introduced into the run() function …

### DIFF
--- a/radioDiags/src_diags/FrequencyScanner.cc
+++ b/radioDiags/src_diags/FrequencyScanner.cc
@@ -392,7 +392,7 @@ void FrequencyScanner::run(bool signalPresent)
     } // if
 
     // Select new frequency.
-    success = radioPtr->setReceiveFrequency(startFrequencyInHertz);
+    success = radioPtr->setReceiveFrequency(currentFrequencyInHertz);
   } // if
 
   return;


### PR DESCRIPTION
…such

that, although the frequency variables did the scan as expected, the hardware
was getting tuned to the start frequency.  That bug is now fixed.