### PR TITLE
There was a problem such that, when starting the transmitter, the warp

### DIFF
--- a/radioDiags/src_diags/Radio.cc
+++ b/radioDiags/src_diags/Radio.cc
@@ -583,11 +583,11 @@ bool Radio::startReceiver(void)
 
       if (status == HACKRF_SUCCESS)
       {
-        // Ensure that the proper frequency is set.
-        status = setFrequency(receiveFrequency);
-
         // Ensure that the system will accept any arriving data.
         receiveEnabled = true;
+
+        // Ensure that the proper frequency is set.
+        status = setFrequency(receiveFrequency);
       } // if
       else
       {
@@ -733,11 +733,11 @@ bool Radio::startTransmitter(void)
 
       if (status == HACKRF_SUCCESS)
       {
-        // Ensure that the proper frequency is set.
-        status = setFrequency(transmitFrequency);
-
         // Ensure that the system will allow transmission of data.
         transmitEnabled = true;
+
+        // Ensure that the proper frequency is set.
+        status = setFrequency(transmitFrequency);
       } // if
       else
       {


### PR DESCRIPTION
wasn't getting set.  After investigation, I discovered that the setTransmitFrequency() function wasn't getting invoked by the setFrequency() function.  This occurred due to the fact that the isTransmitting() function returned false.  Ultimately the problem was that, in the startTransmit() function, the startTransmitter() function was setting the transmitEnabled flag AFTER, the setFrequency() function was invoked. Okay, what a mess! This is finally fixed!